### PR TITLE
feat: 🎸 use "closes" keywoard to close GitHub issues

### DIFF
--- a/lib/formatCommitMessage.js
+++ b/lib/formatCommitMessage.js
@@ -48,7 +48,7 @@ const formatCommitMessage = (state) => {
   }
 
   if (issues) {
-    msg += '\n\nIssues: ' + issues;
+    msg += '\n\nCloses: ' + issues;
   }
 
   return msg;

--- a/lib/questions/issues.js
+++ b/lib/questions/issues.js
@@ -1,5 +1,5 @@
 exports.createQuestion = () => ({
-  message: 'Issues this commit closes:',
+  message: 'Issues this commit closes, e.g #123:',
   name: 'issues',
   type: 'input'
 });


### PR DESCRIPTION
Last "issues" question will emit "Closes:" instead of "Issues:" text,
which should trigger GitHub to actually close the issues.

BREAKING CHANGE: "closes" keyboard is used instead of "issues", which will close GitHub
issues.

Closes: #123