### PR TITLE
fix: 🐛 get config from root or a nested project folder

### DIFF
--- a/lib/getConfig.js
+++ b/lib/getConfig.js
@@ -11,17 +11,24 @@ const configFiles = [
 ];
 
 const findOverrides = (root) => {
-  const dir = root || process.cwd();
+  let pkgFilename;
+  const dirs = [process.cwd()];
 
-  for (const file of configFiles) {
-    const filename = path.join(dir, file);
-
-    if (fs.existsSync(filename)) {
-      return require(filename);
-    }
+  if (root) {
+    dirs.push(root);
   }
 
-  const pkgFilename = path.join(dir, 'package.json');
+  for (const dir of dirs) {
+    for (const file of configFiles) {
+      const filename = path.join(dir, file);
+
+      if (fs.existsSync(filename)) {
+        return require(filename);
+      }
+    }
+
+    pkgFilename = pkgFilename || path.join(dir, 'package.json');
+  }
 
   if (fs.existsSync(pkgFilename)) {
     try {

--- a/lib/getConfig.js
+++ b/lib/getConfig.js
@@ -12,11 +12,7 @@ const configFiles = [
 
 const findOverrides = (root) => {
   let pkgFilename;
-  const dirs = [process.cwd()];
-
-  if (root) {
-    dirs.push(root);
-  }
+  const dirs = [root, process.cwd()].filter((el) => el);
 
   for (const dir of dirs) {
     for (const file of configFiles) {


### PR DESCRIPTION
Our project has structure like this:
```
our_project/
├── server/
│   ├── file1.py
│   ├── file2.py
│   └── file_n.py
└──client/
    ├── file1.js
    ├── file2.js
    ├── file_n.js
    ├── package.json
    └── changelog.config.json
```
We use `git-cz` in our client project part, but .git filder is in the `our_project` directory. When we run command `git cz` in the client folder, `git-cz` starts with default config, doesn't use our `changelog.config.json` file.

This PR aims to find a config file from a root git directory, otherwise find in a nested project folder.