### PR TITLE
fix: remove emojis when disableEmoji is true

### DIFF
--- a/lib/formatCommitMessage.js
+++ b/lib/formatCommitMessage.js
@@ -49,13 +49,13 @@ const formatCommitMessage = (state) => {
   }
 
   if (breaking) {
-    const breakingEmoji = config.disableEmoji ? config.breakingChangePrefix : '';
+    const breakingEmoji = config.disableEmoji ? '' : config.breakingChangePrefix;
 
     msg += '\n\nBREAKING CHANGE: ' + breakingEmoji + breaking;
   }
 
   if (issues) {
-    const closedIssueEmoji = config.disableEmoji ? config.closedIssuePrefix : '';
+    const closedIssueEmoji = config.disableEmoji ? '' : config.closedIssuePrefix;
 
     msg += '\n\n' + closedIssueEmoji + 'Closes: ' + issues;
   }


### PR DESCRIPTION
Remove emojis when `breaking change` and `closes` an issue.