### PR TITLE
fix: 🐛 fix git commit error

### DIFF
--- a/lib/parseArgs.js
+++ b/lib/parseArgs.js
@@ -52,12 +52,12 @@ const parseArgs = () => {
     string: ['type', 'subject', 'scope', 'body', 'breaking', 'issues', 'learna']
   });
 
-  if (help) {
+  if (help || h) {
     console.log(helpScreen);
     process.exit();
   }
 
-  if (version) {
+  if (version || v) {
     console.log(pkg.version);
     process.exit();
   }

--- a/lib/parseArgs.js
+++ b/lib/parseArgs.js
@@ -39,7 +39,9 @@ const parseArgs = () => {
     subject,
     type,
     help,
+    h,
     version,
+    v,
     ...passThroughParams
   } = minimist(process.argv.slice(2), {
     alias: {


### PR DESCRIPTION
Hello! This little addition fixes the error described in the issue #143 

The reason of the error was the additional `h` and `v` properties returned from the minimist as aliases of `help` and `version`.

Since `h` and `v` was not destructured before, they were being passed to the `passThroughParams` and causing git to complain.