### PR TITLE
feat: 🎸 check for staged files

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -27,25 +27,25 @@ const executeCommand = (command, args = [], env = process.env) => {
 
 const main = async () => {
   try {
-    try {
-      /**
-       * @author https://github.com/rodrigograca31
-       * @see https://github.com/streamich/git-cz/issues/177
-       *
-       * It exits with 1 if there were differences and 0 means no differences.
-       * Because of that we negate it to only throw an error if there's no files staged
-       * https://stackoverflow.com/questions/367069/how-can-i-negate-the-return-value-of-a-process
-       */
-      execSync('! git diff HEAD --staged --quiet --exit-code');
-    } catch (error) {
-      throw new Error('No files staged.');
-    }
-
     const {cliAnswers, cliOptions, passThroughParams} = parseArgs();
 
     if (cliOptions.dryRun) {
       // eslint-disable-next-line no-console
       console.log('Running in dry mode.');
+    } else {
+      try {
+        /**
+         * @author https://github.com/rodrigograca31
+         * @see https://github.com/streamich/git-cz/issues/177
+         *
+         * It exits with 1 if there were differences and 0 means no differences.
+         * Because of that we negate it to only throw an error if there's no files staged
+         * https://stackoverflow.com/questions/367069/how-can-i-negate-the-return-value-of-a-process
+         */
+        execSync('! git diff HEAD --staged --quiet --exit-code');
+      } catch (error) {
+        throw new Error('No files staged.');
+      }
     }
 
     const state = createState({disableEmoji: cliOptions.disableEmoji});

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,4 +1,4 @@
-const {spawn} = require('child_process');
+const {spawn, execSync} = require('child_process');
 const fs = require('fs');
 const {join} = require('path');
 const shellescape = require('any-shell-escape');
@@ -27,6 +27,20 @@ const executeCommand = (command, args = [], env = process.env) => {
 
 const main = async () => {
   try {
+    try {
+      /**
+       * @author https://github.com/rodrigograca31
+       * @see https://github.com/streamich/git-cz/issues/177
+       *
+       * It exits with 1 if there were differences and 0 means no differences.
+       * Because of that we negate it to only throw an error if there's no files staged
+       * https://stackoverflow.com/questions/367069/how-can-i-negate-the-return-value-of-a-process
+       */
+      execSync('! git diff HEAD --staged --quiet --exit-code');
+    } catch (error) {
+      throw new Error('No files staged.');
+    }
+
     const {cliAnswers, cliOptions, passThroughParams} = parseArgs();
 
     if (cliOptions.dryRun) {


### PR DESCRIPTION
Closes #177 

I'm a bit concerned about Windows users.
The code uses `!` to negate the output of the `git diff` command but the `!` operator is for POSIX compliant systems.... (aka, Linux and Mac)
https://stackoverflow.com/questions/367069/how-can-i-negate-the-return-value-of-a-process

That said. Where do windows users are running `git cz` nowadays? because `Cygwin` is POSIX compliant but I think the "normal" Windows CLI isnt.... right? Will we have a problem here? or Windows developers are not using the "normal" cmd thing nowadays? :thinking: 

https://en.wikipedia.org/wiki/POSIX