### PR TITLE
fix: 🐛 check for staged files

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -38,13 +38,14 @@ const main = async () => {
          * @author https://github.com/rodrigograca31
          * @see https://github.com/streamich/git-cz/issues/177
          *
-         * It exits with 1 if there were differences and 0 means no differences.
-         * Because of that we negate it to only throw an error if there's no files staged
-         * https://stackoverflow.com/questions/367069/how-can-i-negate-the-return-value-of-a-process
+         * Exits with 1 if there are differences and 0 if no differences.
          */
-        execSync('! git diff HEAD --staged --quiet --exit-code');
+        execSync('git diff HEAD --staged --quiet --exit-code');
+
+        // Executes the following line only if the one above didn't crash (exit code: 0)
+        signale.warn('No files staged!');
       } catch (error) {
-        throw new Error('No files staged.');
+        // eslint-disable no-empty
       }
     }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,4 +1,4 @@
-const {spawn} = require('child_process');
+const {spawn, execSync} = require('child_process');
 const fs = require('fs');
 const {join} = require('path');
 const shellescape = require('any-shell-escape');


### PR DESCRIPTION
removes use of ! and shows warning instead of error

Original issue: #177