### PR TITLE
chore: 🤖 add trailing comma config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
-    "singleQuote": true,
-    "arrowParens": "always",
-    "bracketSpacing": false
+  "singleQuote": true,
+  "arrowParens": "always",
+  "bracketSpacing": false,
+  "trailingComma": "none"
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,7 +16,7 @@ const executeCommand = (command, args = [], env = process.env) => {
   const proc = spawn(formattedCommand, [], {
     env,
     shell: true,
-    stdio: [0, 1, 2]
+    stdio: [0, 1, 2],
   });
 
   proc.on('close', (code) => {
@@ -92,7 +92,7 @@ const main = async () => {
       'commit',
       '--message',
       message,
-      ...appendedArgs
+      ...appendedArgs,
     ];
 
     if (cliOptions.dryRun) {


### PR DESCRIPTION
When using the latest [Prettier 2.0 ](https://prettier.io/blog/2020/03/21/2.0.0.html) the default behavior changed for trailing commas.

This project doesnt use them. 
That means new contributions over time will be adding trailing commas for no reason other than them using Prettier 2.0 (happened to me) 

We can fix this by disabling them. (with this PR)

**Or** we should adopt them and format our files again, because it actually brings some benefits:
https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8

Lets vote? 
:+1: to merge this PR and **not** use trailing commas
:-1: to make a new PR that uses trailing commas (read the benefits)(and we need to "re-prettify" the files)