### PR TITLE
feat: 🎸 exit process when no files staged

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -25,6 +25,7 @@ const executeCommand = (command, args = [], env = process.env) => {
   });
 };
 
+// eslint-disable-next-line complexity
 const main = async () => {
   try {
     const {cliAnswers, cliOptions, passThroughParams} = parseArgs();
@@ -32,7 +33,7 @@ const main = async () => {
     if (cliOptions.dryRun) {
       // eslint-disable-next-line no-console
       console.log('Running in dry mode.');
-    } else {
+    } else if (!passThroughParams['allow-empty']) {
       try {
         /**
          * @author https://github.com/rodrigograca31
@@ -43,7 +44,10 @@ const main = async () => {
         execSync('git diff HEAD --staged --quiet --exit-code');
 
         // Executes the following line only if the one above didn't crash (exit code: 0)
-        signale.warn('No files staged!');
+        signale.error('No files staged!');
+
+        // eslint-disable-next-line no-process-exit
+        process.exit(0);
       } catch (error) {
         // eslint-disable no-empty
       }


### PR DESCRIPTION
instead of showing a warning when there are no staged files, it's better to exit the process with an error message, unless there is `allow-empty` arg passed, cause that means the user want to create an empty commit.

