### PR TITLE
fix: 🐛 use multiple message flags with git commit

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -97,7 +97,7 @@ const main = async () => {
     ];
 
     message.split('\n\n').forEach((part) => {
-      executeCommandArgs.push('-m', part);
+      executeCommandArgs.push('--message', part);
     });
 
     executeCommandArgs.push(...appendedArgs);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -70,7 +70,7 @@ const main = async () => {
     if (cliOptions.hook) {
       const commitMsgFile = join(getGitRootDir(), '.git', 'COMMIT_EDITMSG');
 
-      fs.writeFileSync(commitMsgFile, message);
+      fs.writeFileSync(commitMsgFile, message.join('\n\n'));
       // eslint-disable-next-line no-process-exit
       process.exit(0);
     }
@@ -92,13 +92,11 @@ const main = async () => {
       }
     }
 
-    const executeCommandArgs = [
-      'commit'
-    ];
-
-    message.split('\n\n').forEach((part) => {
-      executeCommandArgs.push('--message', part);
-    });
+    const executeCommandArgs = message.reduce((commandArgs, messagePart) => [
+      ...commandArgs,
+      '--message',
+      messagePart
+    ], ['commit']);
 
     executeCommandArgs.push(...appendedArgs);
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -93,11 +93,14 @@ const main = async () => {
     }
 
     const executeCommandArgs = [
-      'commit',
-      '--message',
-      message,
-      ...appendedArgs
+      'commit'
     ];
+
+    message.split('\n\n').forEach((part) => {
+      executeCommandArgs.push('-m', part);
+    });
+
+    executeCommandArgs.push(...appendedArgs);
 
     if (cliOptions.dryRun) {
       const command = shellescape(['git', ...executeCommandArgs]);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -92,21 +92,25 @@ const main = async () => {
       }
     }
 
-    const executeCommandArgs = message.reduce((commandArgs, messagePart) => [
-      ...commandArgs,
-      '--message',
-      messagePart
-    ], ['commit']);
-
-    executeCommandArgs.push(...appendedArgs);
+    const executeCommandArgs = [
+      'commit',
+      ...message.reduce((commandArgs, messagePart) => [
+        ...commandArgs,
+        '--message',
+        messagePart
+      ], []),
+      ...appendedArgs
+    ];
 
     if (cliOptions.dryRun) {
       const command = shellescape(['git', ...executeCommandArgs]);
 
-      // eslint-disable-next-line no-console
+      /* eslint-disable no-console */
       console.log('Will execute command:');
-      // eslint-disable-next-line no-console
       console.log(command);
+      console.log('Message:');
+      console.log(message.join('\n\n'));
+      /* eslint-enable no-console */
     } else {
       executeCommand('git', executeCommandArgs);
     }

--- a/lib/formatCommitMessage.js
+++ b/lib/formatCommitMessage.js
@@ -1,14 +1,10 @@
 /* eslint-disable complexity */
 
-const wrap = require('word-wrap');
-
-const MAX_LINE_WIDTH = 72;
-
 const makeAffectsLine = function (answers) {
   const selectedPackages = answers.packages;
 
   if (selectedPackages && selectedPackages.length) {
-    return `\naffects: ${selectedPackages.join(', ')}`;
+    return `\n\naffects: ${selectedPackages.join(', ')}`;
   }
 
   return '';
@@ -16,11 +12,6 @@ const makeAffectsLine = function (answers) {
 
 const formatCommitMessage = (state) => {
   const {config, answers} = state;
-  const wrapOptions = {
-    indent: '',
-    trim: true,
-    width: MAX_LINE_WIDTH
-  };
   let head = '';
   let scope = '';
 
@@ -37,12 +28,9 @@ const formatCommitMessage = (state) => {
     head = answers.type + scope + ': ' + emojiPrefix + answers.subject;
   }
 
-  const affectsLine = makeAffectsLine(answers);
-
-  // Wrap these lines at MAX_LINE_WIDTH character
-  const body = wrap((answers.body || '') + affectsLine, wrapOptions);
-  const breaking = wrap(answers.breaking, wrapOptions);
-  const issues = wrap(answers.issues, wrapOptions);
+  const body = ((answers.body || '') + makeAffectsLine(answers)).trim();
+  const breaking = answers.breaking.trim();
+  const issues = answers.issues.trim();
 
   let msg = head;
 

--- a/lib/formatCommitMessage.js
+++ b/lib/formatCommitMessage.js
@@ -28,9 +28,9 @@ const formatCommitMessage = (state) => {
     head = answers.type + scope + ': ' + emojiPrefix + answers.subject;
   }
 
-  const body = ((answers.body || '') + makeAffectsLine(answers)).trim();
-  const breaking = answers.breaking.trim();
-  const issues = answers.issues.trim();
+  const body = (answers.body || '').trim() + makeAffectsLine(answers);
+  const breaking = (answers.breaking || '').trim();
+  const issues = (answers.issues || '').trim();
 
   let msg = head;
 

--- a/lib/formatCommitMessage.js
+++ b/lib/formatCommitMessage.js
@@ -4,7 +4,7 @@ const makeAffectsLine = function (answers) {
   const selectedPackages = answers.packages;
 
   if (selectedPackages && selectedPackages.length) {
-    return `\n\naffects: ${selectedPackages.join(', ')}`;
+    return `affects: ${selectedPackages.join(', ')}`;
   }
 
   return '';
@@ -12,42 +12,34 @@ const makeAffectsLine = function (answers) {
 
 const formatCommitMessage = (state) => {
   const {config, answers} = state;
-  let head = '';
-  let scope = '';
-
-  if (answers.scope && answers.scope !== 'none') {
-    scope = `(${answers.scope})`;
-  }
-
-  if (config.disableEmoji) {
-    head = answers.type + scope + ': ' + answers.subject;
-  } else {
-    const emoji = config.types[answers.type].emoji;
-    const emojiPrefix = emoji ? emoji + ' ' : '';
-
-    head = answers.type + scope + ': ' + emojiPrefix + answers.subject;
-  }
-
-  const body = (answers.body || '').trim() + makeAffectsLine(answers);
+  const scope = answers.scope && answers.scope !== 'none' ? `(${answers.scope})` : '';
+  const scopeEmoji = config.disableEmoji || !config.types[answers.type].emoji ? '' : `${config.types[answers.type].emoji} `;
+  const body = (answers.body || '').trim();
+  const affects = makeAffectsLine(answers);
   const breaking = (answers.breaking || '').trim();
   const issues = (answers.issues || '').trim();
+  const msg = [];
 
-  let msg = head;
+  msg.push(`${answers.type}${scope}: ${scopeEmoji}${answers.subject}`);
 
   if (body) {
-    msg += '\n\n' + body;
+    msg.push(body);
+  }
+
+  if (affects) {
+    msg.push(affects);
   }
 
   if (breaking) {
     const breakingEmoji = config.disableEmoji ? '' : config.breakingChangePrefix;
 
-    msg += '\n\nBREAKING CHANGE: ' + breakingEmoji + breaking;
+    msg.push(`BREAKING CHANGE: ${breakingEmoji}${breaking}`);
   }
 
   if (issues) {
     const closedIssueEmoji = config.disableEmoji ? '' : config.closedIssuePrefix;
 
-    msg += '\n\n' + closedIssueEmoji + 'Closes: ' + issues;
+    msg.push(`${closedIssueEmoji}Closes: ${issues}`);
   }
 
   return msg;

--- a/lib/formatCommitMessage.js
+++ b/lib/formatCommitMessage.js
@@ -1,33 +1,20 @@
 /* eslint-disable complexity */
 
-const makeAffectsLine = function (answers) {
-  const selectedPackages = answers.packages;
-
-  if (selectedPackages && selectedPackages.length) {
-    return `affects: ${selectedPackages.join(', ')}`;
-  }
-
-  return '';
-};
-
 const formatCommitMessage = (state) => {
   const {config, answers} = state;
-  const scope = answers.scope && answers.scope !== 'none' ? `(${answers.scope})` : '';
+  const scope = !answers.scope || answers.scope === 'none' ? '' : `(${answers.scope})`;
   const scopeEmoji = config.disableEmoji || !config.types[answers.type].emoji ? '' : `${config.types[answers.type].emoji} `;
   const body = (answers.body || '').trim();
-  const affects = makeAffectsLine(answers);
   const breaking = (answers.breaking || '').trim();
   const issues = (answers.issues || '').trim();
-  const msg = [];
-
-  msg.push(`${answers.type}${scope}: ${scopeEmoji}${answers.subject}`);
+  const msg = [`${answers.type}${scope}: ${scopeEmoji}${answers.subject}`];
 
   if (body) {
     msg.push(body);
   }
 
-  if (affects) {
-    msg.push(affects);
+  if (Array.isArray(answers.packages) && answers.packages.length > 0) {
+    msg.push(`affects: ${answers.packages.join(', ')}`);
   }
 
   if (breaking) {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "rimraf": "3.0.2",
     "semantic-release": "16.0.4",
     "signale": "1.4.0",
-    "spawncommand": "2.2.0",
-    "word-wrap": "1.2.3"
+    "spawncommand": "2.2.0"
   },
   "husky": {
     "hooks": {

--- a/test/__snapshots__/cli.test.js.snap
+++ b/test/__snapshots__/cli.test.js.snap
@@ -28,5 +28,7 @@ exports[`git-cz --non-interactive 1`] = `
 "Running in dry mode.
 Will execute command:
 git commit --message 'chore: 🤖 automated commit'
+Message:
+chore: 🤖 automated commit
 "
 `;

--- a/test/formatCommitMessage.test.js
+++ b/test/formatCommitMessage.test.js
@@ -102,7 +102,7 @@ describe('formatCommitMessage()', () => {
   it('formats correctly a basic message ("feat" type, emoji, and message)', () => {
     const message = formatCommitMessage({...defaultState});
 
-    expect(message).to.equal('feat: 🎸 First commit');
+    expect(message).to.eql(['feat: 🎸 First commit']);
   });
 
   it('does not include emoji, if emojis disabled in config', () => {
@@ -114,6 +114,6 @@ describe('formatCommitMessage()', () => {
       }
     });
 
-    expect(message).to.equal('feat: First commit');
+    expect(message).to.eql(['feat: First commit']);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9757,7 +9757,7 @@ windows-release@^3.1.0:
   dependencies:
     execa "^1.0.0"
 
-word-wrap@1.2.3, word-wrap@^1.0.3, word-wrap@~1.2.3:
+word-wrap@^1.0.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==


### PR DESCRIPTION
To address the missing body and footer content (long description, breaking changes, linked issues), switch to using multiple message options:
`git commit -m "fix: my scope" -m "my longer description" -m "BREAKING CHANGE: this is just an example" -m "Closes: 188"

This ability to send multiple messages to git commit has been around since (at least) v2.2.3 (09/04/15) and is still available today in v2.28.0

https://git-scm.com/docs/git-commit/2.2.3#Documentation/git-commit.txt--mltmsggt
https://git-scm.com/docs/git-commit/2.27.0#Documentation/git-commit.txt--mltmsggt

Fixes:
https://github.com/streamich/git-cz/issues/188
https://github.com/streamich/git-cz/issues/197