### PR TITLE
fix: 🐛 multiple lines on Windows

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,9 +11,8 @@ const formatCommitMessage = require('./formatCommitMessage');
 const getGitRootDir = require('./util/getGitRootDir');
 
 // eslint-disable-next-line no-process-env
-const executeCommand = (command, args = [], env = process.env) => {
-  const formattedCommand = shellescape([command, ...args]);
-  const proc = spawn(formattedCommand, [], {
+const executeCommand = (command, env = process.env) => {
+  const proc = spawn(command, [], {
     env,
     shell: true,
     stdio: [0, 1, 2]
@@ -96,25 +95,28 @@ const main = async () => {
       }
     }
 
-    const executeCommandArgs = ['commit', ...appendedArgs];
+    const commitMsgFile = join(
+      getGitRootDir(),
+      '.git',
+      'GIT_CZ_COMMIT_MESSAGE'
+    );
+
+    const command = shellescape([
+      'git',
+      'commit',
+      '--file',
+      commitMsgFile,
+      ...appendedArgs,
+    ]);
 
     if (cliOptions.dryRun) {
-      const command = shellescape(['git', ...executeCommandArgs]);
-
       // eslint-disable-next-line no-console
       console.log('Will execute command:');
       // eslint-disable-next-line no-console
-      console.log(command);
+      console.log(command.replace(commitMsgFile));
     } else {
-      const commitMsgFile = join(
-        getGitRootDir(),
-        '.git',
-        'GIT_CZ_COMMIT_MESSAGE'
-      );
-
       fs.writeFileSync(commitMsgFile, message);
-
-      executeCommand('git', [...executeCommandArgs, '--file', commitMsgFile]);
+      executeCommand('git', command);
     }
   } catch (error) {
     signale.fatal(error);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -96,12 +96,7 @@ const main = async () => {
       }
     }
 
-    const executeCommandArgs = [
-      'commit',
-      '--message',
-      message,
-      ...appendedArgs
-    ];
+    const executeCommandArgs = ['commit', ...appendedArgs];
 
     if (cliOptions.dryRun) {
       const command = shellescape(['git', ...executeCommandArgs]);
@@ -111,7 +106,15 @@ const main = async () => {
       // eslint-disable-next-line no-console
       console.log(command);
     } else {
-      executeCommand('git', executeCommandArgs);
+      const commitMsgFile = join(
+        getGitRootDir(),
+        '.git',
+        'GIT_CZ_COMMIT_MESSAGE'
+      );
+
+      fs.writeFileSync(commitMsgFile, message);
+
+      executeCommand('git', [...executeCommandArgs, '--file', commitMsgFile]);
     }
   } catch (error) {
     signale.fatal(error);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -118,7 +118,7 @@ const main = async () => {
       console.log(command.replace(czCommitMsgFile, '.git/GIT_CZ_COMMIT_MESSAGE'));
     } else {
       fs.writeFileSync(czCommitMsgFile, message);
-      executeCommand('git', command);
+      executeCommand(command);
     }
   } catch (error) {
     signale.fatal(error);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -95,7 +95,7 @@ const main = async () => {
       }
     }
 
-    const commitMsgFile = join(
+    const czCommitMsgFile = join(
       getGitRootDir(),
       '.git',
       'GIT_CZ_COMMIT_MESSAGE'
@@ -105,18 +105,19 @@ const main = async () => {
       'git',
       'commit',
       '--file',
-      commitMsgFile,
-      ...appendedArgs,
+      czCommitMsgFile,
+      ...appendedArgs
     ]);
 
     if (cliOptions.dryRun) {
       // eslint-disable-next-line no-console
       console.log('Will execute command:');
+
+      // The full path is replaced with a relative path to make the test pass on every machine
       // eslint-disable-next-line no-console
-      console.log(command.replace(commitMsgFile, '.git/GIT_CZ_COMMIT_MESSAGE'));
-      // replaces the real path with a relative path to make the test pass on every machine
+      console.log(command.replace(czCommitMsgFile, '.git/GIT_CZ_COMMIT_MESSAGE'));
     } else {
-      fs.writeFileSync(commitMsgFile, message);
+      fs.writeFileSync(czCommitMsgFile, message);
       executeCommand('git', command);
     }
   } catch (error) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -66,18 +66,6 @@ const main = async () => {
 
     const message = formatCommitMessage(state);
 
-    /**
-     * @author https://github.com/oxyii
-     * @see https://github.com/streamich/git-cz/issues/79
-     */
-    if (cliOptions.hook) {
-      const commitMsgFile = join(getGitRootDir(), '.git', 'COMMIT_EDITMSG');
-
-      fs.writeFileSync(commitMsgFile, message);
-      // eslint-disable-next-line no-process-exit
-      process.exit(0);
-    }
-
     const appendedArgs = [];
 
     // eslint-disable-next-line guard-for-in
@@ -95,13 +83,13 @@ const main = async () => {
       }
     }
 
-    const czCommitMsgFile = join(getGitRootDir(), '.git', 'COMMIT_EDITMSG');
+    const commitMsgFile = join(getGitRootDir(), '.git', 'COMMIT_EDITMSG');
 
     const command = shellescape([
       'git',
       'commit',
       '--file',
-      czCommitMsgFile,
+      commitMsgFile,
       ...appendedArgs
     ]);
 
@@ -111,13 +99,23 @@ const main = async () => {
 
       // The full path is replaced with a relative path to make the test pass on every machine
       // eslint-disable-next-line no-console
-      console.log(command.replace(czCommitMsgFile, '.git/COMMIT_EDITMSG'));
+      console.log(command.replace(commitMsgFile, '.git/COMMIT_EDITMSG'));
       // eslint-disable-next-line no-console
       console.log('Message:');
       // eslint-disable-next-line no-console
       console.log(message);
     } else {
-      fs.writeFileSync(czCommitMsgFile, message);
+      fs.writeFileSync(commitMsgFile, message);
+
+      /**
+       * @author https://github.com/oxyii
+       * @see https://github.com/streamich/git-cz/issues/79
+       */
+      if (cliOptions.hook) {
+        // eslint-disable-next-line no-process-exit
+        process.exit(0);
+      }
+
       executeCommand(command);
     }
   } catch (error) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -95,11 +95,7 @@ const main = async () => {
       }
     }
 
-    const czCommitMsgFile = join(
-      getGitRootDir(),
-      '.git',
-      'GIT_CZ_COMMIT_MESSAGE'
-    );
+    const czCommitMsgFile = join(getGitRootDir(), '.git', 'COMMIT_EDITMSG');
 
     const command = shellescape([
       'git',
@@ -115,7 +111,11 @@ const main = async () => {
 
       // The full path is replaced with a relative path to make the test pass on every machine
       // eslint-disable-next-line no-console
-      console.log(command.replace(czCommitMsgFile, '.git/GIT_CZ_COMMIT_MESSAGE'));
+      console.log(command.replace(czCommitMsgFile, '.git/COMMIT_EDITMSG'));
+      // eslint-disable-next-line no-console
+      console.log('Message:');
+      // eslint-disable-next-line no-console
+      console.log(message);
     } else {
       fs.writeFileSync(czCommitMsgFile, message);
       executeCommand(command);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -113,7 +113,8 @@ const main = async () => {
       // eslint-disable-next-line no-console
       console.log('Will execute command:');
       // eslint-disable-next-line no-console
-      console.log(command.replace(commitMsgFile));
+      console.log(command.replace(commitMsgFile, '.git/GIT_CZ_COMMIT_MESSAGE'));
+      // replaces the real path with a relative path to make the test pass on every machine
     } else {
       fs.writeFileSync(commitMsgFile, message);
       executeCommand('git', command);

--- a/test/__snapshots__/cli.test.js.snap
+++ b/test/__snapshots__/cli.test.js.snap
@@ -27,6 +27,8 @@ exports[`git-cz --help 1`] = `
 exports[`git-cz --non-interactive 1`] = `
 "Running in dry mode.
 Will execute command:
-git commit --file '.git/GIT_CZ_COMMIT_MESSAGE'
+git commit --file '.git/COMMIT_EDITMSG'
+Message:
+chore: 🤖 automated commit
 "
 `;

--- a/test/__snapshots__/cli.test.js.snap
+++ b/test/__snapshots__/cli.test.js.snap
@@ -27,6 +27,6 @@ exports[`git-cz --help 1`] = `
 exports[`git-cz --non-interactive 1`] = `
 "Running in dry mode.
 Will execute command:
-git commit --message 'chore: 🤖 automated commit'
+git commit --file '.git/GIT_CZ_COMMIT_MESSAGE'
 "
 `;


### PR DESCRIPTION
The description input was disappearing on Windows because of the new
line character. This writes the commit message to a file first and then
uses the --file parameter to read from it.

✅ Closes: #188 #197 #198

@ArrayKnight this should fix it. Can you test an give your opinion?

Leaving this as a draft because I'm gonna re-organize some code first and also have a question for "the community"

**As you can see it writes to a temporary file at: `.git/GIT_CZ_COMMIT_MESSAGE`, should we remove the file after the commit or just leave it?** 🤔
It doesn't bother anyone and git doesn't track it...