### PR TITLE
chore: 🤖 upgrade travis node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ script:
   - yarn test
 node_js:
   - '10'
+  - '12'
+  - '14'
 after_success:
   - yarn release
   - npx ci-scripts slack


### PR DESCRIPTION
Add node 12 and 14 because 12 is the current actively maintained version
of node and 14 is the next one

✅ Closes: #209