### PR TITLE
fix: 🐛 add config option to change closed issue message

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -80,6 +80,7 @@ const questions = [
 
 module.exports = {
   breakingChangePrefix: '🧨 ',
+  closedIssueMessage: 'Closes: ',
   closedIssuePrefix: '✅ ',
   list,
   maxMessageLength: 64,

--- a/lib/formatCommitMessage.js
+++ b/lib/formatCommitMessage.js
@@ -59,7 +59,7 @@ const formatCommitMessage = (state) => {
   if (issues) {
     const closedIssueEmoji = config.disableEmoji ? '' : config.closedIssuePrefix;
 
-    msg += '\n\n' + closedIssueEmoji + 'Closes: ' + issues;
+    msg += '\n\n' + closedIssueEmoji + config.closedIssueMessage + issues;
   }
 
   return msg;

--- a/test/formatCommitMessage.test.js
+++ b/test/formatCommitMessage.test.js
@@ -6,6 +6,7 @@ const defaultConfig = {
   disableEmoji: false,
   breakingChangePrefix: '🧨 ',
   closedIssuePrefix: '✅ ',
+  closedIssueMessage: 'Closes: ',
   commitMessageFormat: '<type><(scope)>: <emoji><subject>',
   list: [
     'test',


### PR DESCRIPTION
Allow the ability to modify closed issues message for use cases where
you don't want to close the issues.

✅ Closes: #215