### PR TITLE
Commitizen version upgrade

### DIFF
--- a/lib/questions/type.js
+++ b/lib/questions/type.js
@@ -5,7 +5,7 @@ const typeToListItem = ({types, disableEmoji}, type) => {
   const prefix = emoji && !disableEmoji ? emoji + '  ' : '';
 
   return {
-    name: prefix + value.padEnd(12, ' ') + description,
+    name: prefix + (value + ':').padEnd(12, ' ') + description,
     value
   };
 };

--- a/lib/questions/type.js
+++ b/lib/questions/type.js
@@ -1,4 +1,3 @@
-const pad = require('pad-right');
 const fuzzy = require('fuzzy');
 
 const typeToListItem = ({types, disableEmoji}, type) => {
@@ -6,7 +5,7 @@ const typeToListItem = ({types, disableEmoji}, type) => {
   const prefix = emoji && !disableEmoji ? emoji + '  ' : '';
 
   return {
-    name: prefix + pad(value + ':', 12, ' ') + description,
+    name: prefix + value.padEnd(12, ' ') + description,
     value
   };
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "browserify": "17.0.0",
     "chai": "4.2.0",
     "chalk": "4.1.0",
-    "commitizen": "2.10.1",
+    "commitizen": "^4.2.2",
     "eslint": "7.10.0",
     "eslint-plugin-babel": "5.3.1",
     "eslint-plugin-filenames": "1.3.2",


### PR DESCRIPTION
pad-right is no longer a dependency of a dependency. because of that, we
need to stop relying on it. `String.padEnd` is the correct alternative
and is supported on NodeJS>=8.2.1