### PR TITLE
fix: 🐛 move check for git folder to top

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -29,6 +29,14 @@ const main = async () => {
   try {
     const {cliAnswers, cliOptions, passThroughParams} = parseArgs();
 
+    let state = null;
+
+    if (cliOptions.disableEmoji) {
+      state = createState({disableEmoji: cliOptions.disableEmoji});
+    } else {
+      state = createState();
+    }
+
     if (cliOptions.dryRun) {
       // eslint-disable-next-line no-console
       console.log('Running in dry mode.');
@@ -54,14 +62,6 @@ const main = async () => {
       } catch (error) {
         // eslint-disable no-empty
       }
-    }
-
-    let state = null;
-
-    if (cliOptions.disableEmoji) {
-      state = createState({disableEmoji: cliOptions.disableEmoji});
-    } else {
-      state = createState();
     }
 
     if (cliOptions.nonInteractive) {


### PR DESCRIPTION
If the command was issued on a non git folder the "git diff" command
would run first and output the help page because it wasnt recognized
because it was not a git repo folder