### PR TITLE
feat: 🎸️ format (custom message) #81

### DIFF
--- a/.git-cz.json
+++ b/.git-cz.json
@@ -1,3 +1,4 @@
 {
-  "disableEmoji": false
+  "disableEmoji": false,
+  "format": "{emoji} {scope}: {subject}"
 }

--- a/.git-cz.json
+++ b/.git-cz.json
@@ -1,4 +1,4 @@
 {
   "disableEmoji": false,
-  "format": "{emoji} {scope}: {subject}"
+  "format": "{type}{scope}: {emoji}{subject}"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,10 @@
 {
-    "singleQuote": true,
-    "arrowParens": "always",
-    "bracketSpacing": false
+  "arrowParens": "always",
+  "bracketSpacing": false,
+  "endOfLine": "auto",
+  "printWidth": 85,
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "none"
 }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
-
 # git-cz
 
 ![image](https://user-images.githubusercontent.com/9773803/49760520-fa6c6f00-fcc4-11e8-84c4-80727f071487.png)
-
 
 ### Without installation
 
@@ -19,7 +17,7 @@ npx git-cz -e
 ```shell
 npm install -g git-cz
 git-cz
-# or 
+# or
 git-cz -e
 ```
 
@@ -38,7 +36,7 @@ npm install --save-dev git-cz
     "commitizen": {
       "path": "git-cz"
     }
-  },
+  }
 }
 ```
 
@@ -61,7 +59,6 @@ run:
 git cz
 ```
 
-
 ## Custom config
 
 You can provide a custom configuration in a `changelog.config.js` file in your repo, or in any parent folder.
@@ -70,80 +67,63 @@ Below is default config:
 
 ```js
 module.exports = {
-  "disableEmoji": false,
-  "list": [
-    "test",
-    "feat",
-    "fix",
-    "chore",
-    "docs",
-    "refactor",
-    "style",
-    "ci",
-    "perf"
-  ],
-  "maxMessageLength": 64,
-  "minMessageLength": 3,
-  "questions": [
-    "type",
-    "scope",
-    "subject",
-    "body",
-    "breaking",
-    "issues",
-    "lerna"
-  ],
-  "scopes": [],
-  "types": {
-    "chore": {
-      "description": "Build process or auxiliary tool changes",
-      "emoji": "🤖",
-      "value": "chore"
+  disableEmoji: false,
+  format: '{type} {scope}: {subject}',
+  list: ['test', 'feat', 'fix', 'chore', 'docs', 'refactor', 'style', 'ci', 'perf'],
+  maxMessageLength: 64,
+  minMessageLength: 3,
+  questions: ['type', 'scope', 'subject', 'body', 'breaking', 'issues', 'lerna'],
+  scopes: [],
+  types: {
+    chore: {
+      description: 'Build process or auxiliary tool changes',
+      emoji: '🤖',
+      value: 'chore'
     },
-    "ci": {
-      "description": "CI related changes",
-      "emoji": "🎡",
-      "value": "ci"
+    ci: {
+      description: 'CI related changes',
+      emoji: '🎡',
+      value: 'ci'
     },
-    "docs": {
-      "description": "Documentation only changes",
-      "emoji": "✏️",
-      "value": "docs"
+    docs: {
+      description: 'Documentation only changes',
+      emoji: '✏️',
+      value: 'docs'
     },
-    "feat": {
-      "description": "A new feature",
-      "emoji": "🎸",
-      "value": "feat"
+    feat: {
+      description: 'A new feature',
+      emoji: '🎸',
+      value: 'feat'
     },
-    "fix": {
-      "description": "A bug fix",
-      "emoji": "🐛",
-      "value": "fix"
+    fix: {
+      description: 'A bug fix',
+      emoji: '🐛',
+      value: 'fix'
     },
-    "perf": {
-      "description": "A code change that improves performance",
-      "emoji": "⚡️",
-      "value": "perf"
+    perf: {
+      description: 'A code change that improves performance',
+      emoji: '⚡️',
+      value: 'perf'
     },
-    "refactor": {
-      "description": "A code change that neither fixes a bug or adds a feature",
-      "emoji": "💡",
-      "value": "refactor"
+    refactor: {
+      description: 'A code change that neither fixes a bug or adds a feature',
+      emoji: '💡',
+      value: 'refactor'
     },
-    "release": {
-      "description": "Create a release commit",
-      "emoji": "🏹",
-      "value": "release"
+    release: {
+      description: 'Create a release commit',
+      emoji: '🏹',
+      value: 'release'
     },
-    "style": {
-      "description": "Markup, white-space, formatting, missing semi-colons...",
-      "emoji": "💄",
-      "value": "style"
+    style: {
+      description: 'Markup, white-space, formatting, missing semi-colons...',
+      emoji: '💄',
+      value: 'style'
     },
-    "test": {
-      "description": "Adding missing tests",
-      "emoji": "💍",
-      "value": "test"
+    test: {
+      description: 'Adding missing tests',
+      emoji: '💍',
+      value: 'test'
     }
   }
 };
@@ -155,7 +135,7 @@ Using `--non-interactive` flag you can run `git-cz` non-interactive mode.
 
 For example:
 
-```
+```bash
 git-cz --non-interactive --type=feat --subject="add onClick prop to component"
 ```
 
@@ -169,21 +149,22 @@ CLI parameters:
 - `--issues`
 - `--lerna`
 
-## Disable Emoji 
+## Disable Emoji
+
 Using `--disable-emoji` flag will disable emoji.
 
 For example:
 
-```
+```bash
 git-cz --disable-emoji
 ```
 
 ## Commit message format
 
-* A commit message consists of a **header**, **body** and **footer**.
-* The header has a **type** and a **subject**:
+- A commit message consists of a **header**, **body** and **footer**.
+- The header has a **type** and a **subject**:
 
-```
+```bash
 <type>[(<scope>)]: <emoji> <subject>
 [BLANK LINE]
 [body]
@@ -201,6 +182,15 @@ Any other line should be limited to 72 character **[automatic wrapping]**
 
 This allows the message to be easier to read on GitHub as well as in various git tools.
 
+### Format
+
+By default the subject format is: `{type} {scope}: {subject}`
+
+Configuring the `format` field in `.git-cz.json` you can customize your own:
+
+- `{emoji} {type} {scope} {subject}`
+- `{type} {scope}: {emoji} {subject}`
+
 ### Type
 
 Must be one of the following:
@@ -215,13 +205,12 @@ Must be one of the following:
 - `ci` &mdash; CI related changes
 - `perf` &mdash; A code change that improves performance
 
-
 ### Subject
 
 The subject contains succinct description of the change:
 
-* Use the imperative, present tense: "change" not "changed" nor "changes"
-* No dot (.) at the end.
+- Use the imperative, present tense: "change" not "changed" nor "changes"
+- No dot (.) at the end.
 
 ### Body
 
@@ -240,18 +229,16 @@ Select the packages the commit affected.
 
 The footer is the place to reference any tasks related to this commit.
 
-
-
 ## Why this Fork?
 
-```
+```bash
 npm i -g git-cz
 added 1 package in 0.612s
 ```
 
 Installs in 0.6s vs 31.1s.
 
-```
+```bash
 npm i -g mol-conventional-changelog
 added 345 packages in 31.076s
 ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Below is default config:
 ```js
 module.exports = {
   disableEmoji: false,
-  format: '{type} {scope}: {subject}',
+  format: '{type}{scope}: {emoji}{subject}',
   list: ['test', 'feat', 'fix', 'chore', 'docs', 'refactor', 'style', 'ci', 'perf'],
   maxMessageLength: 64,
   minMessageLength: 3,
@@ -184,12 +184,12 @@ This allows the message to be easier to read on GitHub as well as in various git
 
 ### Format
 
-By default the subject format is: `{type} {scope}: {subject}`
+By default the subject format is: `{type}{scope}: {subject}`
 
 Configuring the `format` field in `.git-cz.json` you can customize your own:
 
-- `{emoji} {type} {scope} {subject}`
-- `{type} {scope}: {emoji} {subject}`
+- `{type}{scope}: {emoji}{subject}`
+- `{emoji}{scope} {subject}`
 
 ### Type
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,3 +1,5 @@
+const format = '{type}{scope}: {emoji}{subject}';
+
 const types = {
   chore: {
     description: 'Build process or auxiliary tool changes',
@@ -65,8 +67,7 @@ const list = [
 ];
 
 // https://github.com/angular/angular/blob/master/CONTRIBUTING.md#scope
-const scopes = [
-];
+const scopes = [];
 
 const questions = [
   'type',
@@ -82,6 +83,7 @@ module.exports = {
   breakingChangePrefix: '🧨 ',
   closedIssueMessage: 'Closes: ',
   closedIssuePrefix: '✅ ',
+  format,
   list,
   maxMessageLength: 64,
   minMessageLength: 3,

--- a/lib/formatCommitMessage.js
+++ b/lib/formatCommitMessage.js
@@ -27,7 +27,7 @@ const formatCommitMessage = (state) => {
   const subject = answers.subject.trim();
   const type = answers.type;
 
-  const format = config.format || '{emoji} {scope}: {subject}';
+  const format = config.format || '{type}{scope}: {emoji}{subject}';
 
   const affectsLine = makeAffectsLine(answers);
 
@@ -36,8 +36,9 @@ const formatCommitMessage = (state) => {
   const breaking = wrap(answers.breaking, wrapOptions);
   const issues = wrap(answers.issues, wrapOptions);
 
+  // @note(emoji) Add space after emoji (breakingChangePrefix/closedIssueEmoji)
   const head = format
-    .replace(/\{emoji\}/g, emoji)
+    .replace(/\{emoji\}/g, config.disableEmoji ? '' : emoji + ' ')
     .replace(/\{scope\}/g, scope)
     .replace(/\{subject\}/g, subject)
     .replace(/\{type\}/g, type);

--- a/lib/formatCommitMessage.js
+++ b/lib/formatCommitMessage.js
@@ -21,21 +21,13 @@ const formatCommitMessage = (state) => {
     trim: true,
     width: MAX_LINE_WIDTH
   };
-  let head = '';
-  let scope = '';
 
-  if (answers.scope && answers.scope !== 'none') {
-    scope = `(${answers.scope})`;
-  }
+  const emoji = config.types[answers.type].emoji;
+  const scope = answers.scope ? '(' + answers.scope.trim() + ')' : '';
+  const subject = answers.subject.trim();
+  const type = answers.type;
 
-  if (config.disableEmoji) {
-    head = answers.type + scope + ': ' + answers.subject;
-  } else {
-    const emoji = config.types[answers.type].emoji;
-    const emojiPrefix = emoji ? emoji + ' ' : '';
-
-    head = answers.type + scope + ': ' + emojiPrefix + answers.subject;
-  }
+  const format = config.format || '{emoji} {scope}: {subject}';
 
   const affectsLine = makeAffectsLine(answers);
 
@@ -43,6 +35,12 @@ const formatCommitMessage = (state) => {
   const body = wrap((answers.body || '') + affectsLine, wrapOptions);
   const breaking = wrap(answers.breaking, wrapOptions);
   const issues = wrap(answers.issues, wrapOptions);
+
+  const head = format
+    .replace(/\{emoji\}/g, emoji)
+    .replace(/\{scope\}/g, scope)
+    .replace(/\{subject\}/g, subject)
+    .replace(/\{type\}/g, type);
 
   let msg = head;
 

--- a/lib/parseArgs.js
+++ b/lib/parseArgs.js
@@ -13,6 +13,7 @@ const helpScreen = `
         -h, --help          show usage information
         -v, --version       print version info and exit
         --disable-emoji     don't add emoji to commit title
+        --format            custom formatting options for subject
         --non-interactive   run git-cz in non-interactive mode
 
     non-interactive mode options:
@@ -32,6 +33,7 @@ const parseArgs = () => {
     'dry-run': dryRun,
     hook,
     'disable-emoji': disableEmoji,
+    format,
     'non-interactive': nonInteractive,
     body,
     breaking,
@@ -50,8 +52,24 @@ const parseArgs = () => {
       h: 'help',
       v: 'version'
     },
-    boolean: ['version', 'help', 'disable-emoji', 'non-interactive', 'hook', 'dry-run'],
-    string: ['type', 'subject', 'scope', 'body', 'breaking', 'issues', 'learna']
+    boolean: [
+      'version',
+      'help',
+      'disable-emoji',
+      'non-interactive',
+      'hook',
+      'dry-run'
+    ],
+    string: [
+      'format',
+      'type',
+      'subject',
+      'scope',
+      'body',
+      'breaking',
+      'issues',
+      'learna'
+    ]
   });
 
   if (help || h) {
@@ -67,6 +85,7 @@ const parseArgs = () => {
   const cliOptions = {
     disableEmoji,
     dryRun,
+    format,
     help,
     hook,
     nonInteractive,

--- a/test/__snapshots__/cli.test.js.snap
+++ b/test/__snapshots__/cli.test.js.snap
@@ -10,6 +10,7 @@ exports[`git-cz --help 1`] = `
         -h, --help          show usage information
         -v, --version       print version info and exit
         --disable-emoji     don't add emoji to commit title
+        --format            custom formatting options for subject
         --non-interactive   run git-cz in non-interactive mode
 
     non-interactive mode options:

--- a/test/formatCommitMessage.test.js
+++ b/test/formatCommitMessage.test.js
@@ -4,6 +4,7 @@ const formatCommitMessage = require('../lib/formatCommitMessage');
 
 const defaultConfig = {
   disableEmoji: false,
+  format: '{type} {scope}: {subject}',
   breakingChangePrefix: '🧨 ',
   closedIssuePrefix: '✅ ',
   closedIssueMessage: 'Closes: ',

--- a/test/formatCommitMessage.test.js
+++ b/test/formatCommitMessage.test.js
@@ -4,33 +4,15 @@ const formatCommitMessage = require('../lib/formatCommitMessage');
 
 const defaultConfig = {
   disableEmoji: false,
-  format: '{type} {scope}: {subject}',
+  format: '{type}{scope}: {emoji}{subject}',
   breakingChangePrefix: '🧨 ',
   closedIssuePrefix: '✅ ',
   closedIssueMessage: 'Closes: ',
   commitMessageFormat: '<type><(scope)>: <emoji><subject>',
-  list: [
-    'test',
-    'feat',
-    'fix',
-    'chore',
-    'docs',
-    'refactor',
-    'style',
-    'ci',
-    'perf'
-  ],
+  list: ['test', 'feat', 'fix', 'chore', 'docs', 'refactor', 'style', 'ci', 'perf'],
   maxMessageLength: 64,
   minMessageLength: 3,
-  questions: [
-    'type',
-    'scope',
-    'subject',
-    'body',
-    'breaking',
-    'issues',
-    'lerna'
-  ],
+  questions: ['type', 'scope', 'subject', 'body', 'breaking', 'issues', 'lerna'],
   scopes: [],
   types: {
     chore: {
@@ -101,13 +83,7 @@ const defaultState = {
 };
 
 describe('formatCommitMessage()', () => {
-  it('formats correctly a basic message ("feat" type, emoji, and message)', () => {
-    const message = formatCommitMessage({...defaultState});
-
-    expect(message).to.equal('feat: 🎸 First commit');
-  });
-
-  it('does not include emoji, if emojis disabled in config', () => {
+  it('does not include emoji, if emojis disabled in config (no scope)', () => {
     const message = formatCommitMessage({
       ...defaultState,
       config: {
@@ -116,6 +92,57 @@ describe('formatCommitMessage()', () => {
       }
     });
 
-    expect(message).to.equal('feat: First commit');
+    expect(message).equal('feat: First commit');
+  });
+
+  it('does not include emoji, if emojis disabled in config (with scope)', () => {
+    const message = formatCommitMessage({
+      ...defaultState,
+      answers: {
+        ...defaultState.answers,
+        scope: 'init'
+      },
+      config: {
+        ...defaultConfig,
+        disableEmoji: true
+      }
+    });
+
+    expect(message).equal('feat(init): First commit');
+  });
+
+  it('does not include emoji, if emojis disabled in config (custom)', () => {
+    const message = formatCommitMessage({
+      ...defaultState,
+      answers: {
+        ...defaultState.answers,
+        scope: 'init'
+      },
+      config: {
+        ...defaultConfig,
+        format: '{subject} :{scope}{type}',
+        disableEmoji: true
+      }
+    });
+
+    expect(message).equal('First commit :(init)feat');
+  });
+
+  it('does not include emoji, if emojis disabled in config (dynamic custom)', () => {
+    const isDynamic = true;
+    const message = formatCommitMessage({
+      ...defaultState,
+      answers: {
+        ...defaultState.answers,
+        scope: 'init'
+      },
+      config: {
+        ...defaultConfig,
+        format: `{subject} :{scope}{type}${isDynamic && ' [skip ci]'}`,
+        disableEmoji: true
+      }
+    });
+
+    expect(message).equal('First commit :(init)feat [skip ci]');
   });
 });


### PR DESCRIPTION
Add `format` which will accept:
- `{emoji}`
- `{scope}`
- `{subject}`
- `{type}`

Allow user to put these values in any order.

- `'{type}{scope}: {emoji}{subject}'` (default of repo, should not constitute major version bump)

Which can allow for more customization:

- `'{emoji}{scope} {subject}'`
- `'{subject} :{scope}{type}'`

As well as "dynamic" if hooked into a ci/cd system (or anything really):

```text
`{subject} :{scope}{type}${isDynamic && ' [skip ci]'`
```

(Though now that I think about that, that test may be unnecessary.


`emoji` has `' '` added to match: `breakingChangePrefix` and `closedIssueEmoji`


📝️ Note: Added some values to `.prettierrc` to assist with formatting and defaults to match repo

