### PR TITLE
fix: 🐛 give correct .git/ within submodules

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,7 +8,7 @@ const createState = require('./createState');
 const runInteractiveQuestions = require('./runInteractiveQuestions');
 const runNonInteractiveMode = require('./runNonInteractiveMode');
 const formatCommitMessage = require('./formatCommitMessage');
-const getGitRootDir = require('./util/getGitRootDir');
+const getDotGitDir = require('./util/getDotGitDir');
 
 // eslint-disable-next-line no-process-env
 const executeCommand = (command, env = process.env) => {
@@ -89,7 +89,7 @@ const main = async () => {
       }
     }
 
-    const commitMsgFile = join(getGitRootDir(), '.git', 'COMMIT_EDITMSG');
+    const commitMsgFile = join(getDotGitDir(), 'COMMIT_EDITMSG');
 
     const command = shellescape([
       'git',

--- a/lib/util/getDotGitDir.js
+++ b/lib/util/getDotGitDir.js
@@ -1,0 +1,12 @@
+const {execSync} = require('child_process');
+
+const getDotGitDir = () => {
+  const devNull = process.platform === 'win32' ? ' nul' : '/dev/null';
+  const dir = execSync('git rev-parse --git-dir 2>' + devNull)
+    .toString()
+    .trim();
+
+  return dir;
+};
+
+module.exports = getDotGitDir;


### PR DESCRIPTION
In submodules, .git is a file instead of a directory. Therefore, it's impossible to create .git/COMMIT_EDITMSG.

This PR fixes this by giving the correct .git directory for submodules.