### PR TITLE
fix: better support for lerna & npm/yarn workspaces

### DIFF
--- a/lib/util/lerna.js
+++ b/lib/util/lerna.js
@@ -1,81 +1,89 @@
-const {execSync} = require('child_process');
-const path = require('path');
-const fs = require('fs');
+const { execSync } = require('child_process')
+const path = require('path')
+const fs = require('fs')
 
 const isLerna = (state) =>
-  fs.existsSync(path.join(state.root, 'lerna.json'));
+  fs.existsSync(path.join(state.root, 'lerna.json'))
 
 const isDir = (root) => (name) => {
-  const filepath = path.join(root, name);
+  const filepath = path.join(root, name)
 
   try {
-    const stats = fs.statSync(filepath);
+    const stats = fs.statSync(filepath)
 
-    return stats.isDirectory();
+    return stats.isDirectory()
   } catch (error) {
-    return false;
+    return false
   }
-};
-
-const removeLastDirectoryPartOf = (url) => {
-  return url.substring(0, url.lastIndexOf('/'));
 }
 
-const getPackageDirectory = (state) => {
-  const pkgFilename = path.join(state.root, 'package.json');
+const removeLastDirectoryPartOf = (url) => {
+  return url.substring(0, url.lastIndexOf('/'))
+}
+
+const getPackageDirectories = (state) => {
+  const pkgFilename = path.join(state.root, 'package.json')
 
   if (fs.existsSync(pkgFilename)) {
     try {
-      const packagesDirectory = require(pkgFilename).workspaces.packages;
+      const workspacePackages = Array.isArray(require(pkgFilename).workspaces) ? require(pkgFilename).workspaces : require(pkgFilename).workspaces.packages
 
-      if (packagesDirectory) {
+      if (workspacePackages && workspacePackages.length) {
+        return workspacePackages
+          .filter(workspacePackage => workspacePackage.endsWith('*'))
+          .map(workspacePackage => {
+            return removeLastDirectoryPartOf('' + workspacePackage)
+
+          // else {
+          // TODO: support paths that do not end with '*', in that case the package it self is the directory so we don't need to look at inner directories
+          //   return workspacePackage
+          // }
+          })
         // Remove the /* on the tail
-        return removeLastDirectoryPartOf("" + packagesDirectory);
       }
     // eslint-disable-next-line no-empty
     } catch (error) {
     }
   }
 
-  return "packages";
+  return 'packages'
 }
 
 const getAllPackages = (state) => {
   try {
-    const dir = path.join(state.root, getPackageDirectory(state));
-
-    return fs.readdirSync(dir).filter(isDir(dir));
+    const dirs = getPackageDirectories(state).map(dir => path.join(state.root, dir))
+    return dirs.flatMap(dir => fs.readdirSync(dir).filter(isDir(dir)))
   } catch (error) {
-    return [];
+    return []
   }
-};
+}
 
 const getChangedFiles = () => {
   const devNull = process.platform === 'win32' ? ' nul' : '/dev/null'
   return execSync('git diff --cached --name-only 2>' + devNull)
     .toString()
     .trim()
-    .split('\n');
+    .split('\n')
 }
 
 const getChangedPackages = (state) => {
-  const unique = {};
-  const changedFiles = getChangedFiles();
-  const regex = new RegExp("^"+ getPackageDirectory(state) +"\/([^/]+)\/", "is");
+  const unique = {}
+  const changedFiles = getChangedFiles()
+  const regex = new RegExp('^' + getPackageDirectories(state) + '\/([^/]+)\/', 'is')
 
   for (const filename of changedFiles) {
-    const matches = filename.match(regex);
+    const matches = filename.match(regex)
 
     if (matches) {
-      unique[matches[1]] = 1;
+      unique[matches[1]] = 1
     }
   }
 
-  return Object.keys(unique);
-};
+  return Object.keys(unique)
+}
 
 module.exports = {
   getAllPackages,
   getChangedPackages,
   isLerna
-};
+}

--- a/lib/util/lerna.js
+++ b/lib/util/lerna.js
@@ -1,44 +1,44 @@
-const { execSync } = require('child_process')
-const path = require('path')
-const fs = require('fs')
+const {execSync} = require('child_process');
+const path = require('path');
+const fs = require('fs');
 
 const isLerna = (state) =>
-  fs.existsSync(path.join(state.root, 'lerna.json'))
+  fs.existsSync(path.join(state.root, 'lerna.json'));
 
 const isDir = (root) => (name) => {
-  const filepath = path.join(root, name)
+  const filepath = path.join(root, name);
 
   try {
-    const stats = fs.statSync(filepath)
+    const stats = fs.statSync(filepath);
 
-    return stats.isDirectory()
+    return stats.isDirectory();
   } catch (error) {
-    return false
+    return false;
   }
-}
+};
 
-const removeLastDirectoryPartOf = (url) => {
-  return url.substring(0, url.lastIndexOf('/'))
-}
+const removeLastDirectoryPartOf = (url) => url.substring(0, url.lastIndexOf('/'));
 
 const getPackageDirectories = (state) => {
-  const pkgFilename = path.join(state.root, 'package.json')
+  const pkgFilename = path.join(state.root, 'package.json');
 
   if (fs.existsSync(pkgFilename)) {
     try {
-      const workspacePackages = Array.isArray(require(pkgFilename).workspaces) ? require(pkgFilename).workspaces : require(pkgFilename).workspaces.packages
+      const workspacesConfig = require(String(pkgFilename)).workspaces;
+      const workspacePackages = Array.isArray(workspacesConfig) ? workspacesConfig : workspacesConfig.packages;
 
       if (workspacePackages && workspacePackages.length) {
         return workspacePackages
-          .filter(workspacePackage => workspacePackage.endsWith('*'))
-          .map(workspacePackage => {
-            return removeLastDirectoryPartOf('' + workspacePackage)
+          .filter((workspacePackage) => workspacePackage.endsWith('*'))
+          .map((workspacePackage) =>
+            removeLastDirectoryPartOf(String(workspacePackage))
 
           // else {
           // TODO: support paths that do not end with '*', in that case the package it self is the directory so we don't need to look at inner directories
           //   return workspacePackage
           // }
-          })
+          );
+
         // Remove the /* on the tail
       }
     // eslint-disable-next-line no-empty
@@ -46,44 +46,46 @@ const getPackageDirectories = (state) => {
     }
   }
 
-  return 'packages'
-}
+  return 'packages';
+};
 
 const getAllPackages = (state) => {
   try {
-    const dirs = getPackageDirectories(state).map(dir => path.join(state.root, dir))
-    return dirs.flatMap(dir => fs.readdirSync(dir).filter(isDir(dir)))
+    const dirs = getPackageDirectories(state).map((dir) => path.join(state.root, dir));
+
+    return dirs.flatMap((dir) => fs.readdirSync(dir).filter(isDir(dir)));
   } catch (error) {
-    return []
+    return [];
   }
-}
+};
 
 const getChangedFiles = () => {
-  const devNull = process.platform === 'win32' ? ' nul' : '/dev/null'
+  const devNull = process.platform === 'win32' ? ' nul' : '/dev/null';
+
   return execSync('git diff --cached --name-only 2>' + devNull)
     .toString()
     .trim()
-    .split('\n')
-}
+    .split('\n');
+};
 
 const getChangedPackages = (state) => {
-  const unique = {}
-  const changedFiles = getChangedFiles()
-  const regex = new RegExp('^' + getPackageDirectories(state) + '\/([^/]+)\/', 'is')
+  const unique = {};
+  const changedFiles = getChangedFiles();
+  const regex = new RegExp('^' + getPackageDirectories(state) + '\/([^/]+)\/', 'is');
 
   for (const filename of changedFiles) {
-    const matches = filename.match(regex)
+    const matches = filename.match(regex);
 
     if (matches) {
-      unique[matches[1]] = 1
+      unique[matches[1]] = 1;
     }
   }
 
-  return Object.keys(unique)
-}
+  return Object.keys(unique);
+};
 
 module.exports = {
   getAllPackages,
   getChangedPackages,
   isLerna
-}
+};


### PR DESCRIPTION
Related to https://github.com/streamich/git-cz/pull/86  & https://github.com/streamich/git-cz/issues/85

Fixed issues:

1. Currently the lerna/yarn workspaces support is only looking at `workspace.packages` config. npm & yarn workspaces allow you to configure workspaces as an array under `workspaces` directly without an extra `packages` property, if you were using the latter your workspaces won't be picked up and cz would fallback to `packages/` directory.
2. you can set more than 1 workspace in your config, currently cz is expecting one entry to look at, and doesn't support multiple workspace paths (i.e packages/* and apps/*), so cz would fallback to a hardcoded `packages/` directory due to syntax errors when trying to deal with an array as if it was a string
3. You can explicitly set the workspace config to a project directly without using the `*` suffix to directly point to a workspace,  i.e my current config looks like
```json
"workspaces": [
    "packages/*",
    "apps/*",
    "apps/website/backend",
    "apps/website/frontend"
  ],
```
cz was automatically removing the last folder of the path assuming its a `*`, I added a check to only remove the * if the folder ends with one. This worked for my usecase, however backend and frontend apps under website are not picked up as the rest of the cli tries to look for directories under the workspace, so it was returning project's source code instead of the actual package itself, however I think this is ok for now.