### PR TITLE
feat: 🎸 allow user to customize format with issues

### DIFF
--- a/lib/formatCommitMessage.js
+++ b/lib/formatCommitMessage.js
@@ -28,6 +28,7 @@ const formatCommitMessage = (state) => {
   const type = answers.type;
 
   const format = config.format || '{type}{scope}: {emoji}{subject}';
+  const isFormatWithIssues = format.includes('{issues}');
 
   const affectsLine = makeAffectsLine(answers);
 
@@ -41,7 +42,8 @@ const formatCommitMessage = (state) => {
     .replace(/\{emoji\}/g, config.disableEmoji ? '' : emoji + ' ')
     .replace(/\{scope\}/g, scope)
     .replace(/\{subject\}/g, subject)
-    .replace(/\{type\}/g, type);
+    .replace(/\{type\}/g, type)
+    .replace(/\{issues\}/g, issues);
 
   let msg = head;
 
@@ -55,7 +57,8 @@ const formatCommitMessage = (state) => {
     msg += '\n\nBREAKING CHANGE: ' + breakingEmoji + breaking;
   }
 
-  if (issues) {
+  // Does not handle msg if configured format with issues
+  if (issues && !isFormatWithIssues) {
     const closedIssueEmoji = config.disableEmoji ? '' : config.closedIssuePrefix;
 
     msg += '\n\n' + closedIssueEmoji + config.closedIssueMessage + issues;

--- a/test/formatCommitMessage.test.js
+++ b/test/formatCommitMessage.test.js
@@ -111,6 +111,23 @@ describe('formatCommitMessage()', () => {
     expect(message).equal('feat(init): First commit');
   });
 
+  it('does not include emoji, if emojis disabled in config (with issues)', () => {
+    const message = formatCommitMessage({
+      ...defaultState,
+      answers: {
+        ...defaultState.answers,
+        issues: '#123'
+      },
+      config: {
+        ...defaultConfig,
+        disableEmoji: true,
+        format: '{issues} {type}: {subject}'
+      }
+    });
+
+    expect(message).equal('#123 feat: First commit');
+  });
+
   it('does not include emoji, if emojis disabled in config (custom)', () => {
     const message = formatCommitMessage({
       ...defaultState,


### PR DESCRIPTION
This PR allows users to customize format with issues, and `Close: #issue` will not show in commit message if users have configured issues in format. Just as test case in PR:

```javascript
it('does not include emoji, if emojis disabled in config (with issues)', () => {
  const message = formatCommitMessage({
    ...defaultState,
    answers: {
      ...defaultState.answers,
      issues: '#123'
    },
    config: {
      ...defaultConfig,
      disableEmoji: true,
      format: '{issues} {type}: {subject}'
    }
  });

  expect(message).equal('#123 feat: First commit');
});
```

If users don't configure issues in format, the result will be:

```javascript
it('does not include emoji, if emojis disabled in config (without issues)', () => {
  const message = formatCommitMessage({
    ...defaultState,
    answers: {
      ...defaultState.answers,
      issues: '#123'
    },
    config: {
      ...defaultConfig,
      disableEmoji: true
    }
  });

  expect(message).equal('feat: First commit\n\nClosed: #123');
});
```