### PR TITLE
fix: 🐛  Read git-cz config from package.json

### DIFF
--- a/lib/getConfig.js
+++ b/lib/getConfig.js
@@ -23,9 +23,6 @@ const findOverrides = (root) => {
 
   const parent = path.resolve(dir, '..');
 
-  if (parent !== dir) {
-    return findOverrides(parent);
-  }
 
   const pkgFilename = path.join(dir, 'package.json');
 
@@ -40,6 +37,9 @@ const findOverrides = (root) => {
     } catch (error) {}
   }
 
+  if (parent !== dir) {
+    return findOverrides(parent);
+  }
   return {};
 };
 


### PR DESCRIPTION
Check current directory for package.json config before looking in parent directory.

✅  Closes: #411