### PR TITLE
fix: 🐛 support .git file

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -24,6 +24,17 @@ const executeCommand = (command, env = process.env) => {
   });
 };
 
+const getCommitMessageFile = () => {
+  let gitDir = join(getGitRootDir(), '.git');
+  const stats = fs.statSync(gitDir);
+
+  if (stats.isFile()) {
+    gitDir = fs.readFileSync('.git').toString().trim().replace(/^gitdir: /, '');
+  }
+
+  return join(gitDir, 'COMMIT_EDITMSG');
+};
+
 // eslint-disable-next-line complexity
 const main = async () => {
   try {
@@ -89,7 +100,7 @@ const main = async () => {
       }
     }
 
-    const commitMsgFile = join(getGitRootDir(), '.git', 'COMMIT_EDITMSG');
+    const commitMsgFile = getCommitMessageFile();
 
     const command = shellescape([
       'git',


### PR DESCRIPTION
When use `git worktree` command, `.git` of new work directory is file type, `git cz` wouldn't work in the new work directory, so I fixed this issue.