### PR TITLE
fix: 🐛 answers.lerna format commit message with affect key

### DIFF
--- a/lib/createState.js
+++ b/lib/createState.js
@@ -15,7 +15,7 @@ const createState = (config = {}) => {
       body: '',
       breaking: '',
       issues: '',
-      lerna: '',
+      lerna: [],
       scope: '',
       subject: '',
       type: ''

--- a/lib/formatCommitMessage.js
+++ b/lib/formatCommitMessage.js
@@ -4,9 +4,12 @@ const wrap = require('word-wrap');
 
 const MAX_LINE_WIDTH = 72;
 
-const makeAffectsLine = function (answers) {
-  const selectedPackages = answers.packages;
-
+/**
+ * Join affect packages
+ * @param {object} state.answers
+ * @returns string.
+ */
+const makeAffectsLine = function ({lerna: selectedPackages}) {
   if (selectedPackages && selectedPackages.length) {
     return `\naffects: ${selectedPackages.join(', ')}`;
   }

--- a/lib/questions/lerna.js
+++ b/lib/questions/lerna.js
@@ -12,7 +12,7 @@ exports.createQuestion = (state) => {
     choices: allPackages,
     default: changedPackages,
     message: `The packages that this commit has affected (${changedPackages.length} detected)\n`,
-    name: 'packages',
+    name: 'lerna',
     type: 'checkbox'
   };
 


### PR DESCRIPTION
in lerna mode, no normal formatting message, because the key does not correspond.

so. i made some minor fixes.