### PR TITLE
docs: ✏️ fix scope of messages at readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,16 @@ module.exports = {
       description: 'Adding missing tests',
       emoji: '💍',
       value: 'test'
-    },
-    messages: {
-      type: 'Select the type of change that you\'re committing:',
-      customScope: 'Select the scope this component affects:',
-      subject: 'Write a short, imperative mood description of the change:\n',
-      body: 'Provide a longer description of the change:\n ',
-      breaking: 'List any breaking changes:\n',
-      footer: 'Issues this commit closes, e.g #123:',
-      confirmCommit: 'The packages that this commit has affected\n',
-    },
+    }
+  },
+  messages: {
+    type: 'Select the type of change that you\'re committing:',
+    scope: 'Select the scope this component affects:',
+    subject: 'Write a short, imperative mood description of the change:\n',
+    body: 'Provide a longer description of the change:\n ',
+    breaking: 'List any breaking changes:\n',
+    footer: 'Issues this commit closes, e.g #123:',
+    confirmCommit: 'The packages that this commit has affected\n',
   }
 };
 ```


### PR DESCRIPTION
The messages atribute is on the wrong scope and the 'customScope' just work when i change to 'scope'