### PR TITLE
feat: --breaking show breaking changes question

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,6 +9,7 @@ const runInteractiveQuestions = require('./runInteractiveQuestions');
 const runNonInteractiveMode = require('./runNonInteractiveMode');
 const formatCommitMessage = require('./formatCommitMessage');
 const getGitDir = require('./util/getGitDir');
+const ObjectBuilder = require('./util/ObjectBuilder');
 
 // eslint-disable-next-line no-process-env
 const executeCommand = (command, env = process.env) => {
@@ -31,11 +32,11 @@ const main = async () => {
 
     let state = null;
 
-    if (cliOptions.disableEmoji) {
-      state = createState({disableEmoji: cliOptions.disableEmoji});
-    } else {
-      state = createState();
-    }
+    const configFromFlags = new ObjectBuilder()
+      .if(cliOptions.disableEmoji).add({disableEmoji: true})
+      .build();
+
+    state = createState(configFromFlags);
 
     if (cliOptions.dryRun) {
       // eslint-disable-next-line no-console

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -34,6 +34,7 @@ const main = async () => {
 
     const configFromFlags = new ObjectBuilder()
       .if(cliOptions.disableEmoji).add({disableEmoji: true})
+      .if(cliOptions.breaking).add({showBreakingChangeQuestion: true})
       .build();
 
     state = createState(configFromFlags);

--- a/lib/createState.js
+++ b/lib/createState.js
@@ -4,10 +4,20 @@ const getConfig = require('./getConfig');
 const createState = (config = {}) => {
   let root;
 
+  const showBreakingChangeQuestion = config.showBreakingChangeQuestion;
+  delete config.showBreakingChangeQuestion;
+
   try {
     root = getGitRootDir();
   } catch (error) {
     throw new Error('Could not find Git root folder.');
+  }
+
+  const userConfig = getConfig(root);
+  const missingBreakingChangeQuestion = !userConfig.questions.includes('breaking');
+
+  if (showBreakingChangeQuestion && missingBreakingChangeQuestion) {
+    userConfig.questions.push('breaking');
   }
 
   const state = {
@@ -21,7 +31,7 @@ const createState = (config = {}) => {
       type: ''
     },
     config: {
-      ...getConfig(root),
+      ...userConfig,
       ...config
     },
     root

--- a/lib/parseArgs.js
+++ b/lib/parseArgs.js
@@ -26,6 +26,18 @@ const helpScreen = `
         --lerna             Lerna mono-repo packages this commit affects
 `;
 
+/** If the value is empty the flag is true and the answer is undefined,
+ *  in any other case the flag is false and the answer is the value.
+ *
+ * @param {string} value
+ * @returns {[boolean, string]}
+ * */
+const flagAndAnswerValues = (value) => {
+  const isFlagActive = value === '';
+
+  return [isFlagActive, isFlagActive ? undefined : value];
+};
+
 const parseArgs = () => {
   const {
     // eslint-disable-next-line no-unused-vars
@@ -82,7 +94,10 @@ const parseArgs = () => {
     process.exit();
   }
 
+  const [breakingChangeFlag, breakingChangeValue] = flagAndAnswerValues(breaking);
+
   const cliOptions = {
+    breaking: breakingChangeFlag,
     disableEmoji,
     dryRun,
     format,
@@ -94,7 +109,7 @@ const parseArgs = () => {
 
   const cliAnswers = {
     body,
-    breaking,
+    breaking: breakingChangeValue,
     issues,
     lerna,
     scope,

--- a/lib/util/ObjectBuilder.js
+++ b/lib/util/ObjectBuilder.js
@@ -1,0 +1,40 @@
+class ObjectBuilder {
+  constructor (initial) {
+    this.currentObject = initial || {};
+  }
+
+  /**
+   * @param {boolean} condition
+   * @returns {{ add: ConditionalObjectBuilder["add"] }}
+   */
+  if (condition) {
+    return {
+      add: (mappedValues) => {
+        if (condition) {
+          return this.add(mappedValues);
+        }
+
+        return this;
+      }
+    };
+  }
+
+  /**
+   * @param {{ [key: string]: value }} mappedValues
+   * @returns {ConditionalObjectBuilder}
+   */
+  add (mappedValues) {
+    Object.keys(mappedValues)
+      .forEach((key) => {
+        this.currentObject[key] = mappedValues[key];
+      });
+
+    return this;
+  }
+
+  build () {
+    return this.currentObject;
+  }
+}
+
+module.exports = ObjectBuilder;


### PR DESCRIPTION
Allow to add the question of the breaking changes if you don't specify a text and the question isn't in the "questions" list

![image](https://user-images.githubusercontent.com/75090088/188056775-897e31dd-4d01-498c-89aa-6be6507c708b.png)

For example:
![image](https://user-images.githubusercontent.com/75090088/188056959-cf3009e2-3dc2-4ff2-983c-787cf07cde72.png)

but if add `--breaking` without text:
![image](https://user-images.githubusercontent.com/75090088/188057106-bdf89ccd-c851-4e65-8b85-3c5ca337d492.png)

if you use `--breaking "the breaking change"` the question doesn't appear
![image](https://user-images.githubusercontent.com/75090088/188057332-95bea64d-ccb3-4585-af2d-6951e4c9f519.png)
