### PR TITLE
fix: 🐛 wrong COMMIT_EDITMSG on Windows in Cygwin env

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,6 @@
 const {spawn, execSync} = require('child_process');
 const fs = require('fs');
-const {join} = require('path');
+const path = require('path');
 const shellescape = require('any-shell-escape');
 const signale = require('signale');
 const parseArgs = require('./parseArgs');
@@ -89,7 +89,7 @@ const main = async () => {
       }
     }
 
-    const commitMsgFile = join(getGitDir(), 'COMMIT_EDITMSG');
+    const commitMsgFile = path.posix.join(getGitDir(), 'COMMIT_EDITMSG');
 
     const command = shellescape([
       'git',

--- a/lib/util/getGitDir.js
+++ b/lib/util/getGitDir.js
@@ -1,9 +1,7 @@
 const {execSync} = require('child_process');
 
 const getGitDir = () => {
-  const devNull = process.platform === 'win32' ? ' nul' : '/dev/null';
-  const dir = execSync('git rev-parse --absolute-git-dir 2>' + devNull)
-    .toString()
+  const dir = execSync('git rev-parse --absolute-git-dir', {encoding: 'utf8'})
     .trim();
 
   return dir;

--- a/test/__snapshots__/cli.test.js.snap
+++ b/test/__snapshots__/cli.test.js.snap
@@ -24,12 +24,3 @@ exports[`git-cz --help 1`] = `
 
 "
 `;
-
-exports[`git-cz --non-interactive 1`] = `
-"Running in dry mode.
-Will execute command:
-git commit --file '.git/COMMIT_EDITMSG'
-Message:
-chore: 🤖 automated commit
-"
-`;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -20,7 +20,14 @@ test('git-cz --version', async () => {
 test('git-cz --non-interactive', async () => {
   const {getResult} = runCLI(['--non-interactive', '--dry-run']);
 
+  const quote = process.platform === 'win32' ? '"' : '\'';
   const result = await getResult();
 
-  expect(result).toMatchSnapshot();
+  expect(result).toBe(`\
+Running in dry mode.
+Will execute command:
+git commit --file ${quote}.git/COMMIT_EDITMSG${quote}
+Message:
+chore: 🤖 automated commit
+`);
 });


### PR DESCRIPTION
Use `path.posix.join()` instead of `path.join()` to solve path compatibility in Cygwin on Windows

✅ Closes: #622